### PR TITLE
🎉 Add crossplatform keymap 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Disclosure: This package was created for learning purposes. After finishing it I
 # Usage
 
 Allows you to focus on the selected line/text.
-Use ctrl+alt+n to focus on something and escape to cancel.
+
+Use `ctrl+alt+n` on windows/linux or `cmd+alt+n` on mac to toggle the focus.
 
 ![A screenshot of your package](https://raw.githubusercontent.com/diegobanos/focus/master/images/focus.png)

--- a/keymaps/focus.json
+++ b/keymaps/focus.json
@@ -1,6 +1,13 @@
 {
-  "atom-workspace": {
-    "ctrl-alt-n": "focus:toggle",
+  "atom-text-editor": {
     "escape": "focus:destroy"
+  },
+
+  ".platform-darwin atom-text-editor": {
+    "cmd-alt-n": "focus:toggle"
+  },
+
+  ".platform-win32 atom-text-editor, .platform-linux atom-text-editor": {
+    "ctrl-alt-n": "focus:toggle"
   }
 }


### PR DESCRIPTION
Also, the destroy function was removed in favor of the toggle function.
Now you can use `toggle()` to activate and deactivate the effect.